### PR TITLE
feat: add forecast chart data

### DIFF
--- a/backend/app/analysis_service.py
+++ b/backend/app/analysis_service.py
@@ -217,6 +217,25 @@ class AnalysisService:
                 days
             )
 
+            # 将预测结果转换为前端可用的格式
+            forecast_df = forecast_result.get("forecast")
+            if isinstance(forecast_df, pd.DataFrame):
+                # 转换日期和预测值
+                dates = forecast_df["ds"].dt.strftime("%Y-%m-%d").tolist()
+                values = forecast_df["yhat"].round(2).tolist()
+
+                chart_data = {
+                    "type": "line",
+                    "xAxis": {"data": dates},
+                    "series": [{"name": "预测值", "data": values}]
+                }
+
+                forecast_result["forecast"] = {
+                    "dates": dates,
+                    "values": values,
+                    "chart_data": chart_data
+                }
+
             if "error" not in forecast_result:
                 self._save_to_cache(cache_key, forecast_result)
 

--- a/backend/app/llm_service.py
+++ b/backend/app/llm_service.py
@@ -297,6 +297,10 @@ class LLMService:
             formatted["content"]["metrics"] = data["metrics"]
             formatted["display_type"] = "metrics_cards"
 
+        if "forecast" in data:
+            formatted["content"]["chart"] = data["forecast"]["chart_data"]
+            formatted["display_type"] = "chart"
+
         if "chart_data" in data:
             formatted["content"]["chart"] = data["chart_data"]
             formatted["display_type"] = "chart"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Send, Bot, User, TrendingUp, TrendingDown, DollarSign, Users, Package, ChevronDown, Loader } from 'lucide-react';
+import { ChartView } from './components/ChartView';
 
 // Types
 interface Message {
@@ -65,9 +66,10 @@ const MessageBubble: React.FC<{ message: Message }> = ({ message }) => {
   const renderData = () => {
     if (!message.data) return null;
 
-    const { type, content } = message.data;
+    const { type, content, display_type } = message.data;
+    const displayType = display_type || type;
 
-    if (type === 'daily_report') {
+    if (displayType === 'daily_report') {
       const report = content as DailyReport;
       return (
         <div className="mt-4 space-y-4">
@@ -101,7 +103,7 @@ const MessageBubble: React.FC<{ message: Message }> = ({ message }) => {
       );
     }
 
-    if (type === 'metrics_cards') {
+    if (displayType === 'metrics_cards') {
       const metrics = content.metrics as Metrics;
       return (
         <div className="mt-4 grid grid-cols-2 gap-4">
@@ -133,7 +135,7 @@ const MessageBubble: React.FC<{ message: Message }> = ({ message }) => {
       );
     }
 
-    if (type === 'causal_analysis') {
+    if (displayType === 'causal_analysis') {
       return (
         <div className="mt-4 bg-white border rounded-lg p-4">
           <h4 className="font-semibold mb-3">🎯 因果分析结果</h4>
@@ -146,6 +148,14 @@ const MessageBubble: React.FC<{ message: Message }> = ({ message }) => {
           >
             查看完整分析 →
           </button>
+        </div>
+      );
+    }
+
+    if (displayType === 'chart') {
+      return (
+        <div className="mt-4">
+          <ChartView data={content.chart} />
         </div>
       );
     }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -100,6 +100,7 @@ export interface ForecastData {
   confidence_upper?: number[];
   method?: string;
   summary?: ForecastSummary;
+  chart_data?: ChartData;
 }
 
 export interface ForecastSummary {


### PR DESCRIPTION
## Summary
- convert sales forecast dataframe to chart-friendly arrays
- let frontend formatter surface forecast charts
- render forecast chart data in chat UI

## Testing
- `pytest` *(fails: No module named 'clickhouse_connect')*
- `npm test` *(fails: Missing script 'test')*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68932a8419e0832281b86f703f934c72