### PR TITLE
Refactor forecast summary handling

### DIFF
--- a/backend/app/analysis_service.py
+++ b/backend/app/analysis_service.py
@@ -217,10 +217,31 @@ class AnalysisService:
                 days
             )
 
-            if "error" not in forecast_result:
-                self._save_to_cache(cache_key, forecast_result)
+            # 预测失败则直接返回错误
+            if "error" in forecast_result:
+                return forecast_result
 
-            return forecast_result
+            # 转换预测结果为图表数据
+            forecast_df = forecast_result.get("forecast")
+            chart_data = []
+            if isinstance(forecast_df, pd.DataFrame):
+                chart_data = [
+                    {
+                        "date": row["ds"].strftime("%Y-%m-%d"),
+                        "actual": float(row["y"]) if not pd.isna(row["y"]) else None,
+                        "predicted": float(row["yhat"])
+                    }
+                    for _, row in forecast_df.iterrows()
+                ]
+
+            result = {
+                "forecast": forecast_result.get("summary", {}),
+                "chart_data": chart_data,
+                "method": forecast_result.get("method")
+            }
+
+            self._save_to_cache(cache_key, result)
+            return result
 
         except Exception as e:
             print(f"Error getting forecast: {e}")

--- a/backend/app/llm_service.py
+++ b/backend/app/llm_service.py
@@ -280,8 +280,15 @@ class LLMService:
         if "forecast" in data:
             formatted.append("\n📈 预测数据：")
             forecast = data["forecast"]
-            formatted.append(f"- 未来7天总预测: ${forecast.get('total_forecast', 0):,.0f}")
-            formatted.append(f"- 日均预测: ${forecast.get('avg_daily_forecast', 0):,.0f}")
+            formatted.append(
+                f"- 未来{forecast.get('forecast_days', 0)}天总预测: ${forecast.get('total_forecast', 0):,.0f}"
+            )
+            formatted.append(
+                f"- 日均预测: ${forecast.get('avg_daily_forecast', 0):,.0f}"
+            )
+            method = data.get("method")
+            if method:
+                formatted.append(f"- 预测方法: {method}")
 
         return "\n".join(formatted)
 


### PR DESCRIPTION
## Summary
- Return forecast summary and chart data from `AnalysisService.get_sales_forecast`
- Update LLM formatting to consume new forecast summary and include method

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'clickhouse_connect')*


------
https://chatgpt.com/codex/tasks/task_e_68932a85ed78832289070380e014beb6