### PR TITLE
feat: add sales forecast chart

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Send, Bot, User, TrendingUp, TrendingDown, DollarSign, Users, Package, ChevronDown, Loader } from 'lucide-react';
 import { ChartView } from './components/ChartView';
+import { ForecastChart } from './components/ForecastChart';
 
 // Types
 interface Message {
@@ -153,9 +154,26 @@ const MessageBubble: React.FC<{ message: Message }> = ({ message }) => {
     }
 
     if (displayType === 'chart') {
+      const chart = content.chart;
+      if (Array.isArray(chart)) {
+        return (
+          <div className="mt-4">
+            <ForecastChart data={chart} />
+          </div>
+        );
+      }
       return (
         <div className="mt-4">
-          <ChartView data={content.chart} />
+          <ChartView data={chart} />
+        </div>
+      );
+    }
+
+    if (displayType === 'forecast') {
+      const chart = content.chart || content;
+      return (
+        <div className="mt-4">
+          <ForecastChart data={chart} />
         </div>
       );
     }

--- a/frontend/src/components/ForecastChart.tsx
+++ b/frontend/src/components/ForecastChart.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { ChartView } from './ChartView';
+import { useAnalysis } from '../hooks/useAnalysis';
+
+interface ForecastPoint {
+  date: string;
+  actual: number | null;
+  predicted: number;
+  confidence_lower?: number;
+  confidence_upper?: number;
+}
+
+interface ForecastChartProps {
+  data?: ForecastPoint[];
+}
+
+export const ForecastChart: React.FC<ForecastChartProps> = ({ data }) => {
+  const { getForecast } = useAnalysis();
+  const [forecastData, setForecastData] = useState<ForecastPoint[]>(data || []);
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+
+  useEffect(() => {
+    if (data && data.length > 0) {
+      setForecastData(data);
+      setStartDate(data[0].date);
+      setEndDate(data[data.length - 1].date);
+    } else {
+      getForecast().then(res => {
+        if (res && Array.isArray(res.chart_data) && res.chart_data.length > 0) {
+          setForecastData(res.chart_data as ForecastPoint[]);
+          setStartDate(res.chart_data[0].date);
+          setEndDate(res.chart_data[res.chart_data.length - 1].date);
+        }
+      });
+    }
+  }, [data, getForecast]);
+
+  const filtered = forecastData.filter(p => {
+    const afterStart = startDate ? p.date >= startDate : true;
+    const beforeEnd = endDate ? p.date <= endDate : true;
+    return afterStart && beforeEnd;
+  });
+
+  const chart = {
+    type: 'line' as const,
+    title: '销售预测',
+    xAxis: { type: 'category', data: filtered.map(p => p.date) },
+    series: [
+      { name: '实际', data: filtered.map(p => p.actual), type: 'line' },
+      { name: '预测', data: filtered.map(p => p.predicted), type: 'line' },
+    ],
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center space-x-2">
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          className="border rounded px-2 py-1 text-sm"
+        />
+        <span className="text-sm">至</span>
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          className="border rounded px-2 py-1 text-sm"
+        />
+      </div>
+      <ChartView data={chart} />
+    </div>
+  );
+};
+

--- a/frontend/src/hooks/useAnalysis.ts
+++ b/frontend/src/hooks/useAnalysis.ts
@@ -29,7 +29,7 @@ export const useAnalysis = (): UseAnalysisReturn => {
         analysis_type: type,
       });
 
-      return result.data as AnalysisResult;
+      return result as AnalysisResult;
     } catch (err) {
       setError(err as Error);
       return null;
@@ -44,7 +44,7 @@ export const useAnalysis = (): UseAnalysisReturn => {
 
     try {
       const result = await api.getForecast(days);
-      return result.data as ForecastData;
+      return result as ForecastData;
     } catch (err) {
       setError(err as Error);
       return null;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,6 @@
 // ============== src/services/api.ts ==============
 import axios, { AxiosInstance } from 'axios';
+import type { ForecastData } from '../types';
 
 // API配置
 const API_BASE_URL = (import.meta as any).env?.VITE_API_URL || 'http://localhost:8000';
@@ -74,7 +75,7 @@ export const api = {
   },
 
   // 获取预测
-  getForecast: async (days: number = 7) => {
+  getForecast: async (days: number = 7): Promise<ForecastData> => {
     return apiClient.get(`/api/forecast/${days}`);
   },
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -100,7 +100,13 @@ export interface ForecastData {
   confidence_upper?: number[];
   method?: string;
   summary?: ForecastSummary;
-  chart_data?: ChartData;
+  chart_data?: Array<{
+    date: string;
+    actual: number | null;
+    predicted: number;
+    confidence_lower?: number;
+    confidence_upper?: number;
+  }>;
 }
 
 export interface ForecastSummary {


### PR DESCRIPTION
## Summary
- type forecast API responses
- add reusable ForecastChart component with date range filtering
- integrate forecast chart into chat messages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6893301d350c83228defc247aed05c9b