### PR TITLE
Add default item_count and new_users to mock daily report

### DIFF
--- a/backend/app/analysis_service.py
+++ b/backend/app/analysis_service.py
@@ -573,6 +573,8 @@ class AnalysisService:
                 "total_revenue": 25000.0,
                 "total_orders": 500,
                 "unique_customers": 350,
+                "item_count": 0,
+                "new_users": 0,
                 "avg_order_value": 50.0,
                 "promotion_orders": 100,
                 "loyalty_orders": 150

--- a/backend/tests/test_analysis_service.py
+++ b/backend/tests/test_analysis_service.py
@@ -45,3 +45,13 @@ def test_calculate_trends_with_index_dates():
     service = AnalysisService()
     trends = service._calculate_trends(df)
     assert trends["total_revenue"] == 133.33
+
+
+def test_mock_daily_report_includes_optional_metrics():
+    service = AnalysisService()
+    report = service._get_mock_daily_report()
+    metrics = report["metrics"]
+    assert "item_count" in metrics
+    assert metrics["item_count"] == 0
+    assert "new_users" in metrics
+    assert metrics["new_users"] == 0


### PR DESCRIPTION
## Summary
- ensure `_get_mock_daily_report` returns `item_count` and `new_users` defaults
- add regression test verifying mock report includes those metrics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'clickhouse_connect' and 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_689334983548832286cec300e12f7027