### PR TITLE
feat(frontend): configure websocket url via env

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,15 @@
 # Frontend
 
+## Environment Variables
+
+The frontend uses Vite environment variables. Configure the WebSocket API endpoint with `VITE_API_WS_URL` in a `.env` file:
+
+```env
+VITE_API_WS_URL=ws://localhost:8000
+```
+
+This value is used to establish the chat WebSocket connection.
+
 ## Troubleshooting
 
 If the dev server fails to start due to stale optimized dependencies:

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- make WebSocket endpoint configurable via `VITE_API_WS_URL`
- show user-facing error banner when the socket connection fails
- document `VITE_API_WS_URL` in frontend README and add Vite env typings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Cannot find name 'ForecastChart'; 'chart' is declared but its value is never read; Conversion of type 'AxiosResponse<any, any>' to type 'AnalysisResult' may be a mistake)*

------
https://chatgpt.com/codex/tasks/task_e_6893348a83608322881c9fca5f45d74c