### PR TITLE
refactor: wrap markdown with styled container

### DIFF
--- a/frontend/src/components/MarkdownMessage.tsx
+++ b/frontend/src/components/MarkdownMessage.tsx
@@ -22,11 +22,11 @@ export const MarkdownMessage: React.FC<MarkdownMessageProps> = ({ content, class
   };
 
   return (
-    <ReactMarkdown
-      className={`markdown-body ${className}`}
-      remarkPlugins={[remarkGfm, remarkMath]}
-      rehypePlugins={[rehypeKatex, rehypeHighlight]}
-      components={{
+    <div className={`markdown-body ${className}`}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex, rehypeHighlight]}
+        components={{
         // 标题样式
         h1: ({ children }) => (
           <h1 className="text-2xl font-bold mt-6 mb-4 text-gray-900">{children}</h1>
@@ -169,6 +169,7 @@ export const MarkdownMessage: React.FC<MarkdownMessageProps> = ({ content, class
     >
       {content}
     </ReactMarkdown>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- wrap MarkdownMessage output with `markdown-body` div instead of passing className to `ReactMarkdown`

## Testing
- `npm test` *(fails: `vite` resolved to an ESM file and cannot be loaded by `require`)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689494be154883228b9096700c8cc224