### PR TITLE
Refactor intent parsing to rely on LLM output

### DIFF
--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -40,6 +40,7 @@ def test_llm_intent_parsing_high_confidence(monkeypatch):
     assert intent["intent_type"] == "data_query"
     assert intent["entities"]["query_target"] == "orders"
     assert intent["confidence"] == 0.9
+    assert intent["needs_data"] is True
 
 
 def test_llm_intent_parsing_low_confidence_fallback(monkeypatch):
@@ -50,9 +51,9 @@ def test_llm_intent_parsing_low_confidence_fallback(monkeypatch):
 
     monkeypatch.setattr(service, "_parse_intent_with_llm", mock_llm)
     intent = asyncio.run(service.parse_query_intent("预测明天的销量"))
-    assert intent["intent_type"] == "forecast"
+    assert intent["intent_type"] == "general"
     assert intent["confidence"] == 0.2
-    assert intent["entities"]["forecast_type"] == "sales"
+    assert intent["needs_data"] is False
 
 
 def test_generate_response_includes_intent(monkeypatch):


### PR DESCRIPTION
## Summary
- Update LLM intent parser to require specific intent types and entities
- Simplify query intent parsing to rely solely on LLM results with safe defaults
- Adjust tests for new intent parsing behavior

## Testing
- `pytest backend/tests/test_llm_service.py -q`
- `pip install pandas -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6894a1beeb0883229e0fa1d2f2da9ba3