### PR TITLE
fix: pass scroll handler to message bubbles

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -89,7 +89,8 @@ const MessageBubble: React.FC<{
   message: Message;
   onChartPointClick?: (params: any) => void;
   onMetricClick?: (metric: string) => void;
-}> = ({ message, onChartPointClick, onMetricClick }) => {
+  scrollToBottom?: () => void;
+}> = ({ message, onChartPointClick, onMetricClick, scrollToBottom }) => {
   const isUser = message.type === 'user';
   const [showDetails, setShowDetails] = useState(false);
   const [detailData, setDetailData] = useState<any>(null);
@@ -571,6 +572,7 @@ export default function App() {
               message={message}
               onChartPointClick={handleChartPointClick}
               onMetricClick={handleMetricClick}
+              scrollToBottom={scrollToBottom}
             />
           ))}
 


### PR DESCRIPTION
## Summary
- pass scrollToBottom handler from App to MessageBubble
- prevent forecast chart from referencing undefined scrollToBottom

## Testing
- `npm test` *(fails: "vite" resolved to an ESM file)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: TS1005: ',' expected in MarkdownMessage.test.tsx)*
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_6894a622b7548322ba277421996d3257