### PR TITLE
Guard optional ForecastChart onRender

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -248,6 +248,9 @@ const MessageBubble: React.FC<{
     // 预测展示
     if (displayType === 'forecast') {
       const forecastData = content.chart_data || content.chart || content;
+      const handleForecastRender =
+        typeof scrollToBottom === "function" ? () => scrollToBottom() : undefined;
+
       return (
         <div className="mt-4 bg-white rounded-xl shadow-sm border border-gray-100 p-5">
           <div className="mb-4">
@@ -274,7 +277,7 @@ const MessageBubble: React.FC<{
             )}
           </div>
           <div className="min-h-[500px]">
-            <ForecastChart data={forecastData} onRender={() => scrollToBottom?.()} />
+            <ForecastChart data={forecastData} onRender={handleForecastRender} />
           </div>
         </div>
       );


### PR DESCRIPTION
## Summary
- Build `onRender` only when `scrollToBottom` is available in MessageBubble forecast branch

## Testing
- `npm run build` *(fails: src/__tests__/MarkdownMessage.test.tsx(9,4): error TS1005: ',' expected.)*
- `npm test` *(fails: ESM file cannot be loaded by require)*

------
https://chatgpt.com/codex/tasks/task_e_6894ac7b26dc8322a544a028439db48d