### PR TITLE
chore: enable ESM in frontend tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "ume-bot-frontend",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/frontend/src/__tests__/MarkdownMessage.test.tsx
+++ b/frontend/src/__tests__/MarkdownMessage.test.tsx
@@ -6,9 +6,9 @@ import { MarkdownMessage } from '../components/MarkdownMessage';
 describe('MarkdownMessage', () => {
   const markdown = `# Heading 1
 
-```javascript
+\`\`\`javascript
 console.log(42);
-```
+\`\`\`
 
 Inline math $E=mc^2$ and block math:
 
@@ -21,7 +21,7 @@ $$
     const { container } = render(<MarkdownMessage content={markdown} />);
     const heading = screen.getByRole('heading', { level: 1 });
     expect(heading.textContent).toBe('Heading 1');
-    expect(container.querySelector('pre code')?.textContent).toBe('console.log(42);');
+    expect(container.querySelector('pre code')?.textContent).toBe('console.log(42);\n');
     expect(container.querySelector('.katex')).not.toBeNull();
     expect(heading).toMatchSnapshot();
   });

--- a/frontend/src/__tests__/__snapshots__/MarkdownMessage.test.tsx.snap
+++ b/frontend/src/__tests__/__snapshots__/MarkdownMessage.test.tsx.snap
@@ -1,4 +1,6 @@
-exports[`MarkdownMessage renders markdown elements 1`] = `
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MarkdownMessage > renders markdown elements 1`] = `
 <h1
   class="text-2xl font-bold mt-6 mb-4 text-gray-900"
 >


### PR DESCRIPTION
## Summary
- mark frontend package as ESM to satisfy vitest
- fix MarkdownMessage test markup and expectations

## Testing
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6894b5e29ff483229b8d62f6f0cd9751