### PR TITLE
chore: clean up DetailModal imports and state

### DIFF
--- a/frontend/src/components/DetailModal.tsx
+++ b/frontend/src/components/DetailModal.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { X, Download, Share2, Maximize2 } from 'lucide-react';
+import React from 'react';
+import { X, Download, Share2 } from 'lucide-react';
 import { TableView } from './TableView';
 import { ChartView } from './ChartView';
 import { AnalysisView } from './AnalysisView';
@@ -19,8 +19,6 @@ export const DetailModal: React.FC<DetailModalProps> = ({
   data,
   type
 }) => {
-  const [activeTab, setActiveTab] = useState(0);
-
   if (!isOpen) return null;
 
   const renderContent = () => {


### PR DESCRIPTION
## Summary
- remove unused `Maximize2` icon and local `activeTab` state
- drop unnecessary `useState` import in DetailModal

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6894bafeac5c8322906ffd023508e5e3