### PR TITLE
refactor: type runAnalysis to return data

### DIFF
--- a/frontend/src/hooks/useAnalysis.ts
+++ b/frontend/src/hooks/useAnalysis.ts
@@ -28,8 +28,7 @@ export const useAnalysis = (): UseAnalysisReturn => {
         end_date: endDate,
         analysis_type: type,
       });
-
-      return result as AnalysisResult;
+      return result;
     } catch (err) {
       setError(err as Error);
       return null;
@@ -44,7 +43,7 @@ export const useAnalysis = (): UseAnalysisReturn => {
 
     try {
       const result = await api.getForecast(days);
-      return result as ForecastData;
+      return result;
     } catch (err) {
       setError(err as Error);
       return null;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,6 +1,6 @@
 // ============== src/services/api.ts ==============
 import axios, { AxiosInstance } from 'axios';
-import type { ForecastData } from '../types';
+import type { ForecastData, AnalysisResult } from '../types';
 
 // API配置
 const API_BASE_URL = (import.meta as any).env?.VITE_API_URL || 'http://localhost:8000';
@@ -57,12 +57,14 @@ export const api = {
   },
 
   // 运行分析
-  runAnalysis: async (params: {
-    start_date: string;
-    end_date: string;
-    analysis_type?: string;
-  }) => {
-    return apiClient.post('/api/analyze', params);
+  runAnalysis: async (
+    params: {
+      start_date: string;
+      end_date: string;
+      analysis_type?: string;
+    }
+  ): Promise<AnalysisResult> => {
+    return apiClient.post<AnalysisResult>('/api/analyze', params);
   },
 
   // 查询数据


### PR DESCRIPTION
## Summary
- type `api.runAnalysis` to return `AnalysisResult`
- remove unsafe casts when using analysis APIs

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6894bb041c00832288aedd9230294964