### PR TITLE
fix: keep forecast chart within message bubble

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -273,10 +273,11 @@ const MessageBubble: React.FC<{
               </div>
             )}
           </div>
-          {/* 图表容器 - 固定高度 */}
-          <div className="w-full" style={{ height: '350px' }}>
+          {/* 图表容器 */}
+          <div className="w-full">
             <ForecastChart
               data={forecastData}
+              height="350px"
               onRender={() => {
                 setTimeout(() => {
                   if (scrollToBottom) {

--- a/frontend/src/components/ForecastChart.tsx
+++ b/frontend/src/components/ForecastChart.tsx
@@ -17,9 +17,10 @@ interface ForecastChartProps {
   data?: ForecastPoint[] | any;
   onPointClick?: (params: any) => void;
   onRender?: () => void;
+  height?: string;
 }
 
-export const ForecastChart: React.FC<ForecastChartProps> = ({ data, onPointClick, onRender }) => {
+export const ForecastChart: React.FC<ForecastChartProps> = ({ data, onPointClick, onRender, height = '500px' }) => {
   const chartRef = useRef<HTMLDivElement>(null);
   const [chartInstance, setChartInstance] = useState<echarts.ECharts | null>(null);
   const [dateRange, setDateRange] = useState({ start: '', end: '' });
@@ -48,6 +49,12 @@ export const ForecastChart: React.FC<ForecastChartProps> = ({ data, onPointClick
       updateChart();
     }
   }, [chartInstance, data, showConfidence, dateRange, onRender]);
+
+  useEffect(() => {
+    if (chartInstance) {
+      chartInstance.resize();
+    }
+  }, [chartInstance, height]);
 
   const updateChart = () => {
     if (!chartInstance || !data) return;
@@ -432,7 +439,7 @@ export const ForecastChart: React.FC<ForecastChartProps> = ({ data, onPointClick
 
       {/* 图表容器 */}
       <div className="relative">
-        <div ref={chartRef} style={{ width: '100%', height: '500px' }} />
+        <div ref={chartRef} style={{ width: '100%', height }} />
         
         {/* 悬停信息卡片 */}
         {hoveredPoint && (


### PR DESCRIPTION
## Summary
- allow setting a custom height for `ForecastChart` and resize accordingly
- use the new height prop to keep sales forecast chart within chat bubble

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6895a41205188322a774166d63fc30b9